### PR TITLE
fix: spokit_versionの変数名不一致によるアップデートバグを修正

### DIFF
--- a/scripts/lib/utils.sh
+++ b/scripts/lib/utils.sh
@@ -65,7 +65,7 @@ Installdependencies(){
 SpokitUpdateCheck(){
   latest_version=$(curl -s https://api.github.com/repos/btbf/spokit/releases/latest | jq -r '.tag_name')
 
-  if [ "$(printf '%s\n' "$latest_version" "$version" | sort -V | head -n1)" != "$version" ]; then
+  if [ "$(printf '%s\n' "$latest_version" "$spokit_version" | sort -V | head -n1)" != "$spokit_version" ]; then
     echo
     echo -e "${YELLOW}新しいバージョンが利用可能です: ${GREEN}${latest_version}${NC}"
     echo -e "${YELLOW}最新バージョンにアップデートしてください${NC}"

--- a/scripts/spokit.library
+++ b/scripts/spokit.library
@@ -2,7 +2,7 @@
 # SPOKITコアライブラリ
 # 各lib/配下のモジュールをまとめてロードするアグリゲーター
 
-version="0.4.7"
+spokit_version="0.4.7"
 env_path=$HOME/spokit/env
 
 _LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib"


### PR DESCRIPTION
## Summary

### 問題
`SpokitUpdateCheck`（`lib/utils.sh`）内でバージョン変数名が混在していた。

```bash
# 比較に $version を使用（spokit.library が定義）
if [ "$(printf '%s
' "$latest_version" "$version" | sort -V | head -n1)" != "$version" ]

# URLとディレクトリに $spokit_version を使用（spokit.library では未定義！）
base_url=".../refs/tags/${spokit_version}.tar.gz"
cd "spokit-${spokit_version}/scripts"
```

`spokit.library` から呼ばれると `$spokit_version` が空になり、アップデート実行時にダウンロードURLが壊れて**必ず失敗**していた。

### 修正
- `scripts/spokit.library`: `version=` → `spokit_version=` に変更
- `scripts/lib/utils.sh`: 比較箇所の `$version` → `$spokit_version` に統一

これで `spokit.library` / `install.sh` / `airgap-setup.sh` の3ファイルすべてが `spokit_version` で統一される。

## Test plan
- [ ] `SpokitUpdateCheck` でアップデートを選択したときにダウンロードURLが正しく生成されること
- [ ] `install.sh` のバージョン参照が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)